### PR TITLE
データ一括ダウンロード時のデータ取得方法を変更。

### DIFF
--- a/signate/cli.py
+++ b/signate/cli.py
@@ -139,16 +139,11 @@ def download(competition_id, file_id=None, path=None):
     """Download the file of competition"""
     prepare()
     if file_id:
-        api_response = api_instance.post_competition_file(competition_id, file_id)
+        api_response = fileDownload(competition_id, file_id, path)
     else:
         api_response = api_instance.post_competition_files(competition_id)
-    for file in sorted(api_response['data'], key=itemgetter('size')):
-        click.echo(file['name'])
-        if path:
-            wget.download(file['url'], out=path)
-        else:
-            wget.download(file['url'])
-        click.echo()
+        for file in sorted(api_response['data'], key=itemgetter('size')):
+            fileDownload(competition_id, file['fileId'], path)
     for message in api_response.get('warnings', []):
         warn(message)
     success('\nDownload completed.')
@@ -187,6 +182,18 @@ def confirm(required_agreement):
         accept(required_agreement['competitionId'])
     else:
         pass
+
+
+def fileDownload(competition_id, file_id, path):
+    api_response = api_instance.post_competition_file(competition_id, file_id)
+    for file in sorted(api_response['data'], key=itemgetter('size')):
+        click.echo(file['name'])
+        if path:
+            wget.download(file['url'], out=path)
+        else:
+            wget.download(file['url'])
+    click.echo()
+    return api_response
 
 
 def main():

--- a/signate/cli.py
+++ b/signate/cli.py
@@ -186,12 +186,13 @@ def confirm(required_agreement):
 
 def fileDownload(competition_id, file_id, path):
     api_response = api_instance.post_competition_file(competition_id, file_id)
-    for file in sorted(api_response['data'], key=itemgetter('size')):
-        click.echo(file['name'])
-        if path:
-            wget.download(file['url'], out=path)
-        else:
-            wget.download(file['url'])
+    if not api_response['data'][0]:
+        return api_response
+    click.echo(api_response['data'][0]['name'])
+    if path:
+        wget.download(api_response['data'][0]['url'], out=path)
+    else:
+        wget.download(api_response['data'][0]['url'])
     click.echo()
     return api_response
 

--- a/signate/info.py
+++ b/signate/info.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 NAME = 'SIGNATE CLI'
-VERSION = '0.9.6'
+VERSION = '0.9.8'


### PR DESCRIPTION
ダウンロードに時間がかかり署名付きURLの有効期限を超過して403エラーが出る問題を解消。