### PR TITLE
Use get instead of post to get a download list

### DIFF
--- a/signate/cli.py
+++ b/signate/cli.py
@@ -141,7 +141,7 @@ def download(competition_id, file_id=None, path=None):
     if file_id:
         api_response = fileDownload(competition_id, file_id, path)
     else:
-        api_response = api_instance.post_competition_files(competition_id)
+        api_response = api_instance.get_competition_files(competition_id)
         for file in sorted(api_response['data'], key=itemgetter('size')):
             fileDownload(competition_id, file['fileId'], path)
     for message in api_response.get('warnings', []):


### PR DESCRIPTION
competitionId:403 漁業×AIチャレンジ： 魚群検知アルゴリズムの作成
をダウンロードしたときにエラーになりました。
api_instance.post_competition_filesにおいて、504エラーでダウンロードできません。
その一方で、PRにあるように、postではなくgetにするとダウンロードできました。

情報の取得しかしていないようなので、getでよいと思われます。

## Related issue
#8 